### PR TITLE
Update to https in placeholder urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use `https` on placeholder urls.
 
 ## [0.2.1] - 2019-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.2] - 2019-06-05
 ### Fixed
 - Use `https` on placeholder urls.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "native-types",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "builders": {
     "messages": "1.x",
     "pages": "1.x",

--- a/messages/en.json
+++ b/messages/en.json
@@ -23,5 +23,5 @@
   "admin/native-types.video.url": "URL",
   "store/native-types.text": "Your text here",
   "store/native-types.richText": "Lorem ipsum...",
-  "store/native-types.url": "http://example.com"
+  "store/native-types.url": "https://example.com"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -23,5 +23,5 @@
   "admin/native-types.video.url": "URL",
   "store/native-types.text": "Tu texto aquí",
   "store/native-types.richText": "Lorem ipsum...",
-  "store/native-types.url": "http://example.com"
+  "store/native-types.url": "https://example.com"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -23,5 +23,5 @@
   "admin/native-types.video.url": "URL",
   "store/native-types.text": "Seu texto aqui",
   "store/native-types.richText": "Lorem ipsum...",
-  "store/native-types.url": "http://example.com"
+  "store/native-types.url": "https://example.com"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the placeholder urls from `http://example.com` to `https://example.com`

#### What problem is this solving?
In order for the store to be installable all urls in all pages *must* use `https`, else the install prompt shown bellow won't show.

![image](https://user-images.githubusercontent.com/10223856/58975963-b3a39180-879c-11e9-8cca-25c8d7852a06.png)

#### How should this be manually tested?
access [this workspace](https://lucas2--storecomponents.myvtex.com/) in your phone.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
