### PR TITLE
Make schema references simpler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove unnecessary allOf refs from `contentSchemas`
 
 ## [0.4.2] - 2019-07-01
 ### Changed

--- a/pages/contentSchemas.json
+++ b/pages/contentSchemas.json
@@ -27,19 +27,11 @@
     "image": {
       "properties": {
         "description": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/text"
-            }
-          ],
+          "$ref": "#/definitions/text",
           "title": "admin/native-types.image.description"
         },
         "desktop": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/url"
-            }
-          ],
+          "$ref": "#/definitions/url",
           "format": "Image",
           "title": "admin/native-types.image.desktop"
         },
@@ -48,11 +40,7 @@
           "type": "string"
         },
         "mobile": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/url"
-            }
-          ],
+          "$ref": "#/definitions/url",
           "format": "Image",
           "title": "admin/native-types.image.mobile"
         }
@@ -69,11 +57,7 @@
           "type": "boolean"
         },
         "attributeTitle": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/text"
-            }
-          ],
+          "$ref": "#/definitions/text",  
           "title": "admin/native-types.link.attributeTitle"
         },
         "newTab": {
@@ -81,11 +65,7 @@
           "type": "boolean"
         },
         "url": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/url"
-            }
-          ],
+          "$ref": "#/definitions/url",
           "title": "admin/native-types.link.url"
         }
       },
@@ -94,11 +74,7 @@
     },
 
     "richText": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/text"
-        }
-      ],
+      "$ref": "#/definitions/text",
       "format": "RichText",
       "title": "admin/native-types.richText",
       "type": "string",
@@ -113,11 +89,7 @@
     },
 
     "url": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/text"
-        }
-      ],
+      "$ref": "#/definitions/text",  
       "title": "admin/native-types.url",
       "type": "string",
       "examples": ["store/native-types.url"]
@@ -126,35 +98,19 @@
     "video": {
       "properties": {
         "description": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/text"
-            }
-          ],
+          "$ref": "#/definitions/text",
           "title": "admin/native-types.video.description"
         },
         "thumbnail": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/image"
-            }
-          ],
+          "$ref": "#/definitions/image",
           "title": "admin/native-types.video.thumbnail"
         },
         "title": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/text"
-            }
-          ],
+          "$ref": "#/definitions/text" ,
           "title": "admin/native-types.video.title"
         },
         "url": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/url"
-            }
-          ],
+          "$ref": "#/definitions/url",
           "title": "admin/native-types.video.url"
         }
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Removed unnecessary allOf attributes from contentSchemas

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
We don't need to use allOf when all we want is a simple reference

#### How should this be manually tested?
Can edit links or richtext at this workspace:
https://jey--alssports.myvtex.com/admin/cms/storefront

#### Screenshots or example usage

#### Types of changes

- Bug fix (a non-breaking change which fixes an issue)
- New feature (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Requires change to documentation, which has been updated accordingly.
