### PR TITLE
Fix missing keys on `IOMessageWithMarkers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Added key to the spans rendered by `IOMessageWithMarkers`.
+### Fixed
+- Added missing `key` to the spans rendered by `IOMessageWithMarkers`.
 
 ## [0.7.0] - 2020-03-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added key to the spans rendered by `IOMessageWithMarkers`.
 
 ## [0.7.0] - 2020-03-03
 ### Added

--- a/react/IOMessageWithMarkers.tsx
+++ b/react/IOMessageWithMarkers.tsx
@@ -18,7 +18,7 @@ const IOMessageWithMarkers: IOMessageWithMarkersType = ({
   const markerComponents = markers.reduce((acc: Record<string, any>, marker) => {
     // for more information check https://github.com/formatjs/react-intl/blob/master/docs/Components.md#rich-text-formatting
     acc[marker] = (...chunks: any) => (
-      <span className={handles[`${handleBase}-${marker}`]}>{chunks}</span>
+      <span key={marker} className={handles[`${handleBase}-${marker}`]}>{chunks}</span>
     )
     return acc
   }, {})

--- a/react/package.json
+++ b/react/package.json
@@ -11,7 +11,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-intl": "^3.12.0",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "version": "0.7.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4435,10 +4435,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.7.3:
   version "3.7.5"


### PR DESCRIPTION
#### What problem is this solving?

Added key to the spans rendered by `IOMessageWithMarkers`.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/)
Check that there are no errors related to `Savings` (which uses markers) on the console.
