### PR TITLE
Fix exported 'Values' type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Missing `ReactElement` possible value type for messages.
 
 ## [0.7.4] - 2020-12-01
 ### Fixed

--- a/react/formatIOMessage.ts
+++ b/react/formatIOMessage.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react'
 import {
   createIntl,
   createIntlCache,
@@ -9,7 +10,7 @@ type AdaptedMessageDescriptor = MessageDescriptor & {
   intl: IntlShape
 }
 
-export type Values = Record<string, string | number>
+export type Values = Record<string, string | number | ReactElement>
 
 const cache = createIntlCache()
 


### PR DESCRIPTION
#### What problem is this solving?

`IOMessage` and `formatIOMessage` would not correctly support React components being received via `values`.

#### How should this be manually tested?

The app is linked in this [Workspace](https://newslettercustomfields--storecomponents.myvtex.com/). The generated types are being used by `store-newsletter`.

#### Screenshots or example usage

![Screen Shot 2020-12-18 at 10 07 23](https://user-images.githubusercontent.com/27777263/102618028-d4ca9980-4118-11eb-8321-eaea11dcfe78.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change                                                                            |
| --- | ----------------------------------------------------------------------------------------- |
| ✔️  | Bug fix <!-- a non-breaking change which fixes an issue -->                               |
| \_  | New feature <!-- a non-breaking change which adds functionality -->                       |
| \_  | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_  | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |
| \_  | None of the above                                                                         |

